### PR TITLE
Add an operating system check to the tmux config

### DIFF
--- a/tmux.conf.local
+++ b/tmux.conf.local
@@ -11,15 +11,17 @@ set -g @plugin 'dracula/tmux'
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
 run '~/.tmux/plugins/tpm/tpm'
 
-# enable copy-paste http://goo.gl/DN82E
-# enable RubyMotion http://goo.gl/WDlCy
-set -g default-command 'reattach-to-user-namespace -l zsh'
+if-shell '[[ $(uname -s) = Darwin ]]' {
+  # enable copy-paste http://goo.gl/DN82E
+  # enable RubyMotion http://goo.gl/WDlCy
+  set -g default-command 'reattach-to-user-namespace -l zsh'
 
-# Copy and paste on OS X https://www.instapaper.com/read/474738779
-setw -g mode-keys vi
+  # Copy and paste on OS X https://www.instapaper.com/read/474738779
+  setw -g mode-keys vi
 
-bind-key -T copy-mode-vi 'v' send -X begin-selection
-bind-key -T copy-mode-vi 'y' send -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+  bind-key -T copy-mode-vi 'v' send -X begin-selection
+  bind-key -T copy-mode-vi 'y' send -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
 
-unbind -T copy-mode-vi Enter
-bind-key -T copy-mode-vi Enter send -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+  unbind -T copy-mode-vi Enter
+  bind-key -T copy-mode-vi Enter send -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+}


### PR DESCRIPTION
Before, we were using [`reattach-to-user-namespace`][] regardless of the current
operating system. For OSes where this script is not necessary or available, tmux
would fail to initialise. We added an OS check to the tmux configuration to only
load the script when required.

[`reattach-to-user-namespace`]: https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard
