### PR TITLE
Add a default shell to the tmux config

### DIFF
--- a/tmux.conf.local
+++ b/tmux.conf.local
@@ -25,3 +25,5 @@ if-shell '[[ $(uname -s) = Darwin ]]' {
   unbind -T copy-mode-vi Enter
   bind-key -T copy-mode-vi Enter send -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
 }
+
+if-shell 'test -e /usr/bin/zsh' 'set -g default-shell /usr/bin/zsh'


### PR DESCRIPTION
Before, we used whatever shell the machine had defined when starting a tmux
session. We want to use zsh where possible because that's how our dotfiles are
set up. We added a default shell to ensure we use zsh when we can.
