### PR TITLE
🗑️ Drop `jq` from the Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -11,7 +11,6 @@ brew "coreutils"
 brew "gh"
 brew "git"
 brew "imagemagick"
-brew "jq"
 brew "mas"
 brew "openssl@3"
 brew "php", restart_service: true


### PR DESCRIPTION
Before, we installed [`jq`][] to help us parse and format JSON documents. Over time we stopped using it. We dropped `jq` from the Brewfile to remove the redundant installation.

[`jq`]: https://stedolan.github.io/jq/
