### PR TITLE
✨ Add MySQL to the Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -12,6 +12,7 @@ brew "gh"
 brew "git"
 brew "imagemagick"
 brew "mas"
+brew "mysql"
 brew "openssl@3"
 brew "php", restart_service: true
 brew "poppler"


### PR DESCRIPTION
Before, we had no use for any databases beyond PostgreSQL. Our current client uses MySQL. We added MySQL to the Brewfile and will remove it once the engagement ends.
