### PR TITLE
✨ Add PostgreSQL 14 to the Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -16,6 +16,7 @@ brew "mysql"
 brew "openssl@3"
 brew "php", restart_service: true
 brew "poppler"
+brew "postgresql@14"
 brew "rcm"
 brew "reattach-to-user-namespace"
 brew "redis", restart_service: true


### PR DESCRIPTION
Before, we had no explicit listing of PostgreSQL 14 in our Brewfile. thoughtbot had listed it in their laptop setup, and we wanted to ensure we reflected that in ours. We added PostgreSQL 14 to the Brewfile.
