### PR TITLE
🗑️ Drop Terraform from the Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -20,7 +20,6 @@ brew "postgresql@14"
 brew "rcm"
 brew "reattach-to-user-namespace"
 brew "redis", restart_service: true
-brew "terraform@0.12"
 brew "the_silver_searcher"
 brew "tmux"
 brew "universal-ctags", args: ["HEAD"]


### PR DESCRIPTION
Before, we used Terraform to automate building a client's infrastructure. We are no longer engaged with that client, so this program is redundant. We dropped Terraform from the Brewfile.
