### PR TITLE
🐛 Fix the PHP service configuration

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -14,7 +14,7 @@ brew "imagemagick"
 brew "mas"
 brew "mysql"
 brew "openssl@3"
-brew "php", restart_service: true
+brew "php"
 brew "poppler"
 brew "postgresql@14"
 brew "rcm"


### PR DESCRIPTION
Before, we restarted the PHP service every time we updated all our applications. This was unnecessary and caused macOS to push an annoying notification. We fixed the configuration to stop restarting the service.
