### PR TITLE
🐛 Fix the Redis service configuration

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -19,7 +19,7 @@ brew "poppler"
 brew "postgresql@14"
 brew "rcm"
 brew "reattach-to-user-namespace"
-brew "redis", restart_service: true
+brew "redis"
 brew "the_silver_searcher"
 brew "tmux"
 brew "universal-ctags", args: ["HEAD"]


### PR DESCRIPTION
Before, we restarted the Redis service every time we updated all our applications. This was unnecessary and caused macOS to push an annoying notification. We fixed the configuration to stop restarting the service.
