### PR TITLE
🗑️ Drop 1Blocker from the Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -41,7 +41,6 @@ cask "spotify"
 cask "tuple"
 cask "whatsapp"
 cask "zoom"
-mas "1Blocker", id: 1365531024
 mas "1Password 7", id: 1333542190
 mas "Bear", id: 1091189122
 mas "Things", id: 904280696


### PR DESCRIPTION
Before, we used [1Blocker][] to block ads and cookie prompts while browsing the web. We wanted to experiment without any blocker to see how things worked out. We dropped 1Blocker from the Brewfile.

[1blocker]: https://1blocker.com
