### PR TITLE
🔧 Make Git rebase stacked branches

### DIFF
--- a/gitconfig.local
+++ b/gitconfig.local
@@ -1,5 +1,7 @@
 [commit]
   gpgsign = true
+[rebase]
+  updateRefs = true
 [user]
   name = Rob Whittaker
   signingKey = Rob Whittaker <rob@purinkle.co.uk>


### PR DESCRIPTION
Before, it was a challenge to maintain Git branches that branch off one another. Since Git 2.38, it has been possible to [get Git to do this work for us][]. We made Git rebase stacked branches using the `updateRefs` configuration.

[get git to do this work for us]: https://adamj.eu/tech/2022/10/15/how-to-rebase-stacked-git-branches/
