### PR TITLE
🗑️ Drop 1Password 7 from the Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -42,7 +42,6 @@ cask "spotify"
 cask "tuple"
 cask "whatsapp"
 cask "zoom"
-mas "1Password 7", id: 1333542190
 mas "Bear", id: 1091189122
 mas "Things", id: 904280696
 mas "Tweetbot", id: 1384080005


### PR DESCRIPTION
Before, we upgraded to 1Password 8, which uses `brew` instead of `cask` to stay updated. We still had the old 1Password 7 definition, but it was no longer needed. We dropped 1Password 7 from the Brewfile.
