### PR TITLE
✨ Add 1Password for Safari to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -43,6 +43,7 @@ cask "spotify"
 cask "tuple"
 cask "whatsapp"
 cask "zoom"
+mas "1Password for Safari", id: 1569813296
 mas "Bear", id: 1091189122
 mas "Things", id: 904280696
 mas "Tweetbot", id: 1384080005


### PR DESCRIPTION
Before, 1Password 7 had a built-in Safari extension. Since upgrading to 1Password 8, the Safari extension is now a separate application. We added 1Password for Safari to the Brewfile.
