### PR TITLE
🔧 Make tmux clear the status bars

### DIFF
--- a/tmux.conf.local
+++ b/tmux.conf.local
@@ -27,3 +27,6 @@ if-shell '[[ $(uname -s) = Darwin ]]' {
 }
 
 if-shell 'test -e /usr/bin/zsh' 'set -g default-shell /usr/bin/zsh'
+
+set-option -g status-left ""
+set-option -g status-right ""


### PR DESCRIPTION
Before, [the Dracula tmux plugin][] added values to tmux's status bars. We wanted a clean and minimal setup, and these values added noise. We made tmux clear the status bars.

[the dracula tmux plugin]: https://draculatheme.com/tmux
