### PR TITLE
🐛 Fix the `git branches` alias

### DIFF
--- a/gitconfig.local
+++ b/gitconfig.local
@@ -1,3 +1,5 @@
+[alias]
+  branches = for-each-ref --sort=-committerdate --format=\"%(color:blue)%(authordate:relative)\t%(color:red)%(authorname)\t%(color:black)%(color:bold)%(refname:short)\" refs/remotes
 [commit]
   gpgsign = true
 [rebase]


### PR DESCRIPTION
Before, the `git branches` alias would output the branch name in white. After switching to a light theme in our setup, the name was no longer visible. We fixed the `git branches` alias to use black instead of white.
