### PR TITLE
✨ Add the Hardtime Vim plugin

### DIFF
--- a/vimrc.bundles.local
+++ b/vimrc.bundles.local
@@ -1,1 +1,2 @@
 Plug 'dracula/vim', { 'as': 'dracula' }
+Plug 'takac/vim-hardtime'

--- a/vimrc.local
+++ b/vimrc.local
@@ -10,3 +10,4 @@ let g:ale_fixers = {
 let g:ale_fix_on_save = 1
 
 colorscheme dracula
+let g:hardtime_default_on = 1


### PR DESCRIPTION
Before, we had fallen into the habit of moving around Vim using the movement keys. We could have been more efficient by using better movement commands. We added the [Hardtime][] Vim plugin to disable the single-character movement keys.

[hardtime]: https://github.com/takac/vim-hardtime
