### PR TITLE
✨ Add the papercolor theme to Vim

### DIFF
--- a/vimrc.bundles.local
+++ b/vimrc.bundles.local
@@ -1,2 +1,3 @@
 Plug 'dracula/vim', { 'as': 'dracula' }
 Plug 'takac/vim-hardtime'
+Plug 'NLKNguyen/papercolor-theme'

--- a/vimrc.local
+++ b/vimrc.local
@@ -11,3 +11,6 @@ let g:ale_fix_on_save = 1
 
 colorscheme dracula
 let g:hardtime_default_on = 1
+set t_Co=256
+set background=light
+colorscheme PaperColor


### PR DESCRIPTION
Before, we used the Dracula theme in Vim. Since moving to a light setup, having a dark editor no longer made sense. We added the papercolor colour scheme to Vim to complement our new light settings.
