### PR TITLE
✨ Add 1Blocker to the Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -43,6 +43,7 @@ cask "spotify"
 cask "tuple"
 cask "whatsapp"
 cask "zoom"
+mas "1Blocker", id: 1365531024
 mas "1Password for Safari", id: 1569813296
 mas "Bear", id: 1091189122
 mas "Things", id: 904280696


### PR DESCRIPTION
Before, we experimented with browsing the internet without using an ad blocker. This turned out to be a terrible experience. We added 1Blocker back to the Brewfile.
