### PR TITLE
🗑️ Drop the "Dracula" colour scheme from Vim

### DIFF
--- a/vimrc.bundles.local
+++ b/vimrc.bundles.local
@@ -1,3 +1,2 @@
-Plug 'dracula/vim', { 'as': 'dracula' }
 Plug 'takac/vim-hardtime'
 Plug 'NLKNguyen/papercolor-theme'

--- a/vimrc.local
+++ b/vimrc.local
@@ -8,8 +8,6 @@ let g:ale_fixers = {
 \  'ruby': ['standardrb'],
 \}
 let g:ale_fix_on_save = 1
-
-colorscheme dracula
 let g:hardtime_default_on = 1
 set t_Co=256
 set background=light


### PR DESCRIPTION
Before, we added the "Papercolor" colour scheme to Vim. We no longer needed to have "Dracula" installed. We dropped the "Dracula" colour scheme from Vim.
