### PR TITLE
✨ Add 1Password's Homebrew tap

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,4 @@
+tap "1password/tap"
 tap "heroku/brew"
 tap "homebrew/bundle"
 tap "homebrew/cask"


### PR DESCRIPTION
Before, we installed the 1Password CLI from Homebrew's default formulae. Homebrew warned that we should use 1Password's formulae instead. We added 1Password's Homebrew tap to the Brewfile.
