### PR TITLE
🔧 Make Vim use the Solarized (light) colour scheme

### DIFF
--- a/vimrc.bundles.local
+++ b/vimrc.bundles.local
@@ -1,2 +1,4 @@
+" Make our colour scheme pretty.
+Plug 'altercation/vim-colors-solarized'
+
 Plug 'takac/vim-hardtime'
-Plug 'NLKNguyen/papercolor-theme'

--- a/vimrc.local
+++ b/vimrc.local
@@ -9,6 +9,11 @@ let g:ale_fixers = {
 \}
 let g:ale_fix_on_save = 1
 let g:hardtime_default_on = 1
-set t_Co=256
+
+" Set up the Solarized (light) colour scheme. We have to set the terminal
+" colours to 256 because it looked wrong with only 16 colours. This is likely
+" related to the fact we are yet to set up Terminal.app to use the same theme.
+let g:solarized_termcolors=256
+syntax enable
 set background=light
-colorscheme PaperColor
+colorscheme solarized


### PR DESCRIPTION
Before, we were using the Paper Color theme for Vim. We got a bit bored of this and decided to use something a bit more "classic". We made Vim use the Solarized (light) colour scheme.
