### PR TITLE
🗑️ Drop WhatsApp

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -41,7 +41,6 @@ cask "microsoft-teams"
 cask "rectangle"
 cask "spotify"
 cask "tuple"
-cask "whatsapp"
 cask "zoom"
 mas "1Blocker", id: 1365531024
 mas "1Password for Safari", id: 1569813296


### PR DESCRIPTION
Before, we used to have WhatsApp installed on our local machines. We have since removed personal communication tools from our laptops. We dropped WhatsApp from the Brewfile to prevent us from installing it again in the future.
