### PR TITLE
🐛 Fix Vim's color scheme

### DIFF
--- a/vimrc.bundles.local
+++ b/vimrc.bundles.local
@@ -1,4 +1,4 @@
 " Make our colour scheme pretty.
-Plug 'altercation/vim-colors-solarized'
+Plug 'NLKNguyen/papercolor-theme'
 
 Plug 'takac/vim-hardtime'


### PR DESCRIPTION
Before, we updated our Vim configuration to use the PaperColor color scheme. Unfortunately, we forgot to include the correct plugin for the color scheme. We fixed our Vim bundles file to have the PaperColor color scheme.
