### PR TITLE
♻️ Refactor the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # dotfiles
 
-## Install
+A set of vim, zsh, git, and tmux configuration files.
+
+## Usage
 
 Clone onto your laptop:
 
@@ -20,11 +22,19 @@ Update all the things:
 uatt
 ```
 
-## Update
-
 From time to time you should pull down any updates to these dotfiles, and run
 the following to link any new files and install new vim plugins.
 
 ```shell
 uatt
 ```
+
+## Contributing
+
+Thank you, [contributors][]!
+
+## About
+
+dotfiles is maintained by Rob Whittaker.
+
+[contributors]: https://github.com/purinkle/dotfiles/graphs/contributors


### PR DESCRIPTION
Before, the project's README was light on information. Collaborators needed help understanding who maintains the project or the project's intention. We refactored the README to match thoughtbot's template.
