### PR TITLE
✨ Add a Desktop alias

### DIFF
--- a/aliases.local
+++ b/aliases.local
@@ -6,3 +6,4 @@ alias .....="cd ../../../.."
 # Shortcuts
 alias d="cd ~/Library/CloudStorage/Dropbox"
 alias dl="cd ~/Downloads"
+alias dt="cd ~/Desktop"


### PR DESCRIPTION
Before, it was a challenge to remember how to navigate to the Desktop directory. We wasted time trying to figure out the correct path. We added a simple `dt` alias to simplify the process.
