### PR TITLE
✨ Add a default Vim `colorscheme`

### DIFF
--- a/vimrc.bundles.local
+++ b/vimrc.bundles.local
@@ -1,0 +1,1 @@
+Plug 'catppuccin/vim', { 'as': 'catppuccin' }

--- a/vimrc.local
+++ b/vimrc.local
@@ -1,0 +1,2 @@
+set termguicolors
+colorscheme catppuccin_latte


### PR DESCRIPTION
Before, we had no default Vim `colorscheme`, which left us at the behest of our terminal. We added a `colorscheme` to our Vim configuration to make it more appealing.
