### PR TITLE
🐛 Fix the `asdf` configuration

### DIFF
--- a/zshrc.local
+++ b/zshrc.local
@@ -1,0 +1,1 @@
+export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"


### PR DESCRIPTION
Before, we had not added `asdf` into `PATH`, which meant that macOS was looking for system Ruby and JavaScript. We fixed the configuration by adding the `asdf` shim directory to `PATH` as per [their guides][].

[their guides]: https://web.archive.org/web/20251220054329/https://asdf-vm.com/guide/getting-started.html#_2-configure-asdf
