### PR TITLE
🔧 Make the laptop script upgrade dependencies

### DIFF
--- a/laptop.local
+++ b/laptop.local
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+brew upgrade


### PR DESCRIPTION
Before, we installed recommended dependencies via thoughtbot's `laptop` script. We never automated the updating of them. Our dependencies soon became outdated. We made the `laptop` script upgrade those dependencies.
