### PR TITLE
✨ Add a client-specific setup script

### DIFF
--- a/client.local
+++ b/client.local
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+brew bundle --file=- <<EOF
+brew "opensearch"
+EOF

--- a/laptop.local
+++ b/laptop.local
@@ -1,3 +1,9 @@
 #!/bin/sh
 
+if [ -f "$HOME/.client.local" ]; then
+  fancy_echo "Running your customizations from ~/.client.local ..."
+  # shellcheck disable=SC1091
+  . "$HOME/.client.local"
+fi
+
 brew upgrade


### PR DESCRIPTION
Before, we installed client-specific dependencies on an ad-hoc basis. It was challenging to track what we'd installed. We added a client-specific setup script to help us stay informed.
