### PR TITLE
🗑️ Drop upstreamed changes

### DIFF
--- a/vimrc.bundles.local
+++ b/vimrc.bundles.local
@@ -1,1 +1,0 @@
-Plug 'catppuccin/vim', { 'as': 'catppuccin' }

--- a/vimrc.local
+++ b/vimrc.local
@@ -1,2 +1,0 @@
-set termguicolors
-colorscheme catppuccin_latte

--- a/zshrc.local
+++ b/zshrc.local
@@ -1,1 +1,0 @@
-export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"


### PR DESCRIPTION
Before, we made changes to our personal dotfiles. We have since upstreamed them into `thoughtbot/dotfiles`. There was no need to keep the duplicate entries here. We dropped the upstreamed changes.
