### PR TITLE
🗑️ Drop the setting of `INC_APPEND_HISTORY`

### DIFF
--- a/zshrc.local
+++ b/zshrc.local
@@ -1,0 +1,1 @@
+unsetopt incappendhistory


### PR DESCRIPTION
Before, we set `INC_APPEND_HISTORY` and `SHARE_HISTORY` in our zsh configuration. According to [the documentation][], setting both is unnecessary.

> [SHARE_HISTORY] both imports new commands from the history file, and also causes your typed commands to be appended to the history file (the latter is like specifying INC_APPEND_HISTORY, which should be turned off if this option is in effect). The history lines are also output with timestamps ala EXTENDED_HISTORY (which makes it easier to find the spot where we left off reading the file after it gets re-written).

We unset `INC_APPEND_HISTORY` to avoid any future confusion.

[the documentation]: https://zsh.sourceforge.io/Doc/Release/Options.html
