### PR TITLE
Add an ignore file just for the Hub project

### DIFF
--- a/git-hub.config
+++ b/git-hub.config
@@ -1,0 +1,7 @@
+# Hub-only git config (included via gitconfig.local's includeIf).
+# A repo-scoped core.excludesfile REPLACES the global ~/.gitignore for this
+# repo, so git-hub.ignore mirrors the global patterns and adds Hub's personal
+# working artifacts on top.
+
+[core]
+	excludesfile = ~/dotfiles-local/git-hub.ignore

--- a/git-hub.ignore
+++ b/git-hub.ignore
@@ -1,0 +1,32 @@
+# Hub-only ignore file (git core.excludesfile for ~/Developer/thoughtbot/hub).
+#
+# A repo-scoped core.excludesfile REPLACES, rather than extends, the global
+# ~/.gitignore, so the global patterns are mirrored here first, then Hub's
+# personal working artifacts are added below. The shared git_template
+# .git/info/exclude (**/.claude/... runtime files) still applies independently,
+# as does Hub's own tracked .gitignore.
+
+# Mirrored from ~/.gitignore (dotfiles/gitignore):
+*.pyc
+*.sw[nop]
+.DS_Store
+.bundle
+.byebug_history
+.env
+.git/
+/bower_components/
+/log
+/node_modules/
+/tmp
+db/*.sqlite3
+log/*.log
+rerun.txt
+tmp/**/*
+/tags
+
+**/.claude/settings.local.json
+
+# Hub personal working artifacts (issue loop, PRDs, local agent rule):
+/issues/
+/prd/
+/.claude/rules/issue-tracker.md

--- a/gitconfig.local
+++ b/gitconfig.local
@@ -1,0 +1,5 @@
+# Personal, machine-local git config, sourced by ~/.gitconfig's `[include]`.
+# Repo-scoped overrides live in their own fragment files, wired via includeIf.
+
+[includeIf "gitdir:~/Developer/thoughtbot/hub/"]
+	path = ~/dotfiles-local/git-hub.config


### PR DESCRIPTION
The Hub project keeps personal working notes on disk, under `issues/`,
`prd/`, and `.claude/rules/issue-tracker.md`. They help while the work
is going on, but they are nobody else's business. They should not show
up as new files every time `git status` runs.

Hub's own `.gitignore` is shared with the whole team, so personal paths
do not belong there. The shared `git_template/info/exclude` file is
used by every project, so it is far too broad. This change gives Hub a
list of its own instead.

The `gitconfig.local` file now watches for work inside Hub's folder.
When it sees that, it loads `git-hub.config`, which points git at
`git-hub.ignore` for the list of things to skip.

One catch is worth knowing. When a project names its own list, that
list takes the place of the usual one rather than adding to it. So
`git-hub.ignore` repeats every pattern from the shared list first, then
adds Hub's own paths at the end.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>