### PR TITLE
Add the Trello CLI to the laptop setup

### DIFF
--- a/laptop.local
+++ b/laptop.local
@@ -19,6 +19,22 @@ cask "spotify"
 cask "tuple"
 EOF
 
+# The Trello CLI is a command you run by hand. Nothing here calls it.
+#
+# Homebrew does not carry it, so it is installed as an npm package instead.
+# npm puts it beside whichever version of node asdf is currently using, which
+# ties the command to that version. Change the node version in
+# ~/.tool-versions and this has to be installed again. The `asdf reshim` step
+# is what makes the new `trello` command visible to the shell.
+#
+# Signing in is a manual step. Run `trello auth` once and finish the login in
+# a browser. The token is saved in ~/.trello-cli/, so keep a copy of it in
+# 1Password.
+if command -v npm >/dev/null 2>&1 && ! command -v trello >/dev/null 2>&1; then
+  npm install -g trello-cli
+  asdf reshim nodejs
+fi
+
 if [ -f "$HOME/.client.local" ]; then
   fancy_echo "Running your customizations from ~/.client.local ..."
   # shellcheck disable=SC1091


### PR DESCRIPTION
Trello is used by hand during the day, so the command should already be
there after a fresh laptop is set up rather than being remembered later.

Homebrew does not carry this tool, so it cannot join the `brew bundle`
block above. It is an npm package instead, and npm installs it beside
whichever version of node asdf is using at the time. That has two
knock-on effects. The install has to happen after node exists, which is
why it sits here rather than earlier. And `asdf reshim` has to run
afterwards, or the shell will not find the new command.

The guard checks two things before doing any work. It skips the install
when npm is missing, so the file still runs on a machine without node.
It also skips when `trello` is already there, so running the setup again
costs nothing.

Signing in stays manual. It needs a browser, so no script can do it.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>