### PR TITLE
Add docker-buildx for Kamal deploys

### DIFF
--- a/laptop.local
+++ b/laptop.local
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 brew bundle --file=- <<EOF
+brew "docker-buildx"
 brew "php"
 brew "slack-mcp-server"
 cask "1password"
@@ -34,6 +35,20 @@ if command -v npm >/dev/null 2>&1 && ! command -v trello >/dev/null 2>&1; then
   npm install -g trello-cli
   asdf reshim nodejs
 fi
+
+# Buildx is the part of Docker that builds images. Kamal cannot deploy
+# without it. Installing it here is not quite enough, and the rest is still
+# done by hand. Two steps are missing.
+#
+# Homebrew puts the plugin in /opt/homebrew/lib/docker/cli-plugins. The docker
+# command does not look there, so that folder has to be listed under
+# "cliPluginsExtraDirs" in ~/.docker/config.json.
+#
+# Docker Desktop, if it was ever installed and then removed, leaves broken
+# shortcuts behind in ~/.docker/cli-plugins. Those shortcuts win over the
+# Homebrew copies, so they have to be deleted.
+#
+# Doing both of those here, safely and repeatably, is the next job.
 
 if [ -f "$HOME/.client.local" ]; then
   fancy_echo "Running your customizations from ~/.client.local ..."


### PR DESCRIPTION
Kamal builds a Docker image every time it deploys. That build needs
buildx, which is a separate piece of Docker rather than part of the main
command. Without it a deploy stops before it starts, and the error does
not say which piece is missing.

Homebrew has it, so it joins the list above and arrives with everything
else on a new machine.

That alone does not finish the job, and the comment in the file spells
out the rest. Homebrew puts the plugin somewhere the docker command does
not look, so a settings file has to point at it. An old Docker Desktop
install can also leave broken shortcuts behind that hide the Homebrew
copies. Both are still done by hand today.

Writing those two steps out as code is worth doing, but it means editing
a settings file safely and more than once, so it is kept as a separate
job rather than smuggled in here.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>