### PR TITLE
Make ~/.bin win over the asdf shims

### DIFF
--- a/zshrc.local
+++ b/zshrc.local
@@ -1,1 +1,13 @@
 unsetopt incappendhistory
+
+# Put ~/.bin back at the front of the list of places the shell looks for
+# commands.
+#
+# The shared config already adds ~/.bin near the front, and says in a comment
+# that it should be first. It then adds the asdf shims folder ahead of it a
+# moment later, which quietly undoes that. A script in ~/.bin sharing a name
+# with something asdf manages would be skipped.
+#
+# This file is read last, so adding it again here wins. The shell drops
+# repeats from the list, so ~/.bin moves rather than appearing twice.
+export PATH="$HOME/.bin:$PATH"


### PR DESCRIPTION
Scripts kept in ~/.bin should be the ones that run when their name is
typed. The shared config says the same thing in a comment next to where
it adds that folder.

It does not hold, though. A moment after adding ~/.bin, the shared
config adds the asdf shims folder ahead of it. Shims are small stand-ins
that asdf puts in front of tools like ruby and node so it can pick the
version a project asks for. Anything in ~/.bin sharing a name with one
of those tools is skipped, and nothing warns that it happened.

This file is read after all of that, so naming the folder again here
moves it back to the front. The shell keeps only one copy of each entry
in the list, so this moves ~/.bin rather than listing it twice.

This is worth sending upstream once it has settled, since the promise it
restores is one the shared config already makes.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>