### PR TITLE
Add the Ralph loop scripts

### DIFF
--- a/ralph/once.sh
+++ b/ralph/once.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+# Run one turn of the Ralph loop, where Claude picks a job and does it.
+#
+# Usage: once.sh <path-to-the-project>
+#
+# This script is kept here, in dotfiles, rather than inside the project it
+# works on. That way the loop is saved and shared once instead of being
+# copied into every project, and a project's own history stays free of it.
+#
+# It moves into the project given as the first argument, so the notes in
+# issues/ and the recent commits it reads come from that project. It finds
+# prompt.md by looking next to itself, which keeps working wherever it is
+# run from.
+
+repo="${1:?usage: once.sh <target-repo-dir>}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cd "$repo"
+
+issues=$(cat issues/*.md 2>/dev/null || echo "No issues found")
+commits=$(git log -n 5 --format="%H%n%ad%n%B---" --date=short 2>/dev/null || echo "No commits found")
+prompt=$(cat "$script_dir/prompt.md")
+
+claude --permission-mode acceptEdits \
+  "Previous commits: $commits Issues: $issues $prompt"

--- a/ralph/prompt.md
+++ b/ralph/prompt.md
@@ -1,0 +1,59 @@
+# ISSUES
+
+Local issue files from `issues/` are provided at start of context. Parse them to understand the open issues.
+
+You will work on the AFK issues only, not the HITL ones.
+
+You've also been passed a file containing the last few commits. Review these to understand what work has been done.
+
+If all AFK tasks are complete, output <promise>NO MORE TASKS</promise>.
+
+# TASK SELECTION
+
+Pick the next task. Prioritize tasks in this order:
+
+1. Critical bugfixes
+2. Development infrastructure
+
+Getting development infrastructure like tests and types and dev scripts ready is an important precursor to building features.
+
+3. Tracer bullets for new features
+
+Tracer bullets are small slices of functionality that go through all layers of the system, allowing you to test and validate your approach early. This helps in identifying potential issues and ensures that the overall architecture is sound before investing significant time in development.
+
+TL;DR - build a tiny, end-to-end slice of the feature first, then expand it out.
+
+4. Polish and quick wins
+5. Refactors
+
+# EXPLORATION
+
+Explore the repo.
+
+# IMPLEMENTATION
+
+Use /tdd to complete the task.
+
+# FEEDBACK LOOPS
+
+Before committing, run the feedback loops:
+
+- `./bin/rails default` to run tests and linters
+
+# COMMIT
+
+Make a git commit. The commit message must:
+
+1. Include key decisions made
+2. Include files changed
+3. Blockers or notes for next iteration
+
+# THE ISSUE
+
+If the task is complete, move the issue file to `issues/done/`.
+
+If the task is not complete, add a note to the issue file with what was done.
+
+# FINAL RULES
+
+ONLY WORK ON A SINGLE TASK.


### PR DESCRIPTION
Ralph is a way of letting Claude work on its own for a while. It reads
the open jobs in a project, picks one, does it, and commits. Running it
again picks up the next job.

The two files were being copied by hand into each project that used
them, which meant fixes to one copy never reached the others. It also
put working notes into repos that belong to clients. Keeping them in
dotfiles gives one copy that every project shares, and leaves those
repos alone.

once.sh runs a single turn. It takes the project folder as its first
argument and moves there first, so the jobs and the recent commits it
reads are that project's. It finds prompt.md by looking next to itself,
so it works no matter where it is called from.

prompt.md is what Claude is told. It sets the order jobs are picked in,
asks for the smallest useful slice of a feature first, and says to stop
after one job.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>