### PR TITLE
Add a name and email for git to use

### DIFF
--- a/gitconfig.local
+++ b/gitconfig.local
@@ -1,5 +1,18 @@
 # Personal, machine-local git config, sourced by ~/.gitconfig's `[include]`.
 # Repo-scoped overrides live in their own fragment files, wired via includeIf.
 
+# Say who is making the commits, rather than letting git work it out.
+#
+# With no name given, git falls back to the full name on the macOS account.
+# With no email given, it invents one from the login name and the computer
+# name, which is not a real address. That is why several projects have ended
+# up with a copy of these two lines of their own.
+#
+# The rules further down are more exact than this one, so work for a client
+# still gets that client's address.
+[user]
+	name = Rob Whittaker
+	email = rob@purinkle.co.uk
+
 [includeIf "gitdir:~/Developer/thoughtbot/hub/"]
 	path = ~/dotfiles-local/git-hub.config


### PR DESCRIPTION
Git was never told who is making the commits here. It has been guessing
one part and inventing the other.

For the name it falls back to the full name on the macOS account. For
the email it builds an address from the login name and the computer
name, and that address does not exist. The usual way this gets noticed
is a commit that GitHub cannot match to anyone.

Because of that, several projects on this machine each hold their own
copy of these two lines. Setting them once here means a fresh clone is
right straight away, and those copies can go later.

It matters more now that every commit is signed. GitHub checks a
signature by looking for one account that holds both the signing key and
the email on the commit. If the email is one git made up, no account
holds it, and the check quietly fails.

The rules further down the file are more exact than this one, so client
work keeps using the address it already used.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>