### PR TITLE
Add signing to every commit made here

### DIFF
--- a/gitconfig.local
+++ b/gitconfig.local
@@ -10,9 +10,26 @@
 #
 # The rules further down are more exact than this one, so work for a client
 # still gets that client's address.
+#
+# Signing uses the SSH key that is already unlocked for pushing, so there is
+# nothing extra to type and no second passphrase to look after. The matching
+# public key has to be added to GitHub a second time, as a signing key, under
+# Settings, then SSH and GPG keys, then New signing key. Adding it once as a
+# login key is not enough.
+#
+# The allowed signers file is a local list of which key belongs to which
+# email. Git needs it to show the signature as good in `git log`. GitHub does
+# not use it.
 [user]
 	name = Rob Whittaker
 	email = rob@purinkle.co.uk
+	signingkey = ~/.ssh/id_rsa.pub
+[gpg]
+	format = ssh
+[gpg "ssh"]
+	allowedSignersFile = ~/.ssh/allowed_signers
+[commit]
+	gpgsign = true
 
 [includeIf "gitdir:~/Developer/thoughtbot/hub/"]
 	path = ~/dotfiles-local/git-hub.config


### PR DESCRIPTION
A signed commit proves it came from the person named on it. Without one,
anyone can put any name and address on a commit and GitHub will show it
as though that person wrote it. Signing every commit means the ones on
this machine carry that proof, and GitHub marks them Verified.

The signing is done with the SSH key that is already unlocked for
pushing. The older way uses GPG, which means a second key, a second
passphrase, and a small program running to remember it. Reusing the SSH
key avoids all of that, and there is nothing extra to type.

Two things have to be set up by hand for this to work.

- The same public key must be added to GitHub a second time, as a
  signing key, under Settings, then SSH and GPG keys, then New signing
  key. The copy added for logging in does not count.

- ~/.ssh/allowed_signers must list which key belongs to which email.
  That file is what lets `git log --show-signature` say the signature is
  good. GitHub does not read it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>