### PR TITLE
Add a password helper for Heroku git remotes

### DIFF
--- a/gitconfig.local
+++ b/gitconfig.local
@@ -31,5 +31,13 @@
 [commit]
 	gpgsign = true
 
+# Let the Heroku command answer git's password prompt for Heroku's own
+# servers. The password is a short-lived one the Heroku command makes on the
+# spot, so there is nothing worth saving in a password manager or a keychain.
+# Without this, pushing to a Heroku remote stops and asks for a password that
+# nobody knows.
+[credential "https://git.heroku.com"]
+	helper = !heroku git:credentials
+
 [includeIf "gitdir:~/Developer/thoughtbot/hub/"]
 	path = ~/dotfiles-local/git-hub.config


### PR DESCRIPTION
Pushing to a Heroku git remote asks for a password. There is no password
to give. Heroku uses a short-lived one that its own command line tool
makes fresh each time, so nothing is written down and nothing sits in a
password manager or a keychain.

This tells git to ask that tool for the password whenever it talks to
Heroku's git servers. The prompt goes away and the push carries on.

The setting is limited to Heroku's own address, so it changes nothing
about how any other host is reached.

This lived as an uncommitted edit inside the shared thoughtbot dotfiles
checkout, where it was one `git checkout` away from being lost and
invisible to `rcup`. Personal settings belong here instead, which is the
whole point of this repo.

It may be worth sending upstream later. The shared setup already
installs the Heroku command line tool, so anyone who pushes to Heroku
hits the same prompt.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>