### PR TITLE
Fix Ralph losing its prompt when run via ~/.ralph

### DIFF
--- a/ralph/once.sh
+++ b/ralph/once.sh
@@ -15,7 +15,29 @@ set -euo pipefail
 # run from.
 
 repo="${1:?usage: once.sh <target-repo-dir>}"
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Work out the real folder this script lives in, following any shortcuts on
+# the way.
+#
+# rcup puts a shortcut to this script at ~/.ralph/once.sh, but not one to
+# prompt.md, because it is told to skip every .md file. So ~/.ralph holds the
+# script and nothing else. Asking only for the folder the shortcut sits in
+# gives ~/.ralph, where prompt.md is not, and the script dies.
+#
+# The loop below swaps a shortcut for whatever it points at, over and over,
+# until it reaches the real file in this repo. Its neighbour prompt.md is then
+# right there. A shortcut can point at a relative path, so anything that is
+# not already a full path is joined to the folder the shortcut was in.
+source_path="${BASH_SOURCE[0]}"
+while [ -L "$source_path" ]; do
+  link_dir="$(cd -P "$(dirname "$source_path")" && pwd)"
+  source_path="$(readlink "$source_path")"
+  case $source_path in
+    /*) ;;
+    *) source_path="$link_dir/$source_path" ;;
+  esac
+done
+script_dir="$(cd -P "$(dirname "$source_path")" && pwd)"
 
 cd "$repo"
 


### PR DESCRIPTION
Running ~/.ralph/once.sh stopped the loop before it started, saying it
could not read prompt.md.

rcup makes a shortcut for every file in this repo, but it is told to
skip anything ending in .md. So it made ~/.ralph/once.sh and left
prompt.md behind, and ~/.ralph ends up holding the script on its own.
The script then asked which folder it was sitting in, got ~/.ralph,
looked there for prompt.md, and found nothing. Running it by its full
path in this repo always worked, which made the fault look random.

The script now follows the shortcut back to the real file before asking
which folder it is in. That lands in this repo, where prompt.md sits
beside it. The loop repeats in case a shortcut points at another
shortcut, and it joins on the folder it came from when a shortcut
points at a relative path.

Both ways of starting it now read the same prompt, checked with a
stand-in for the claude command. Fixing the script rather than renaming
prompt.md keeps the file as markdown and leaves the shared rcup settings
alone.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>