### PR TITLE
Stop keeping client settings in a public repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,9 +55,23 @@ One test that saves time: if the change can be staged here at all, it probably b
 
 ### Client settings are never committed
 
-This repo is public. A settings file for a client names that client, and often says something about how their code is reached, so it stays out of git altogether. Add it to `.git/info/exclude`, which is a list of things to ignore that only exists on this machine, and keep a copy in 1Password.
+This repo is public. A settings file for a client names that client, says which folder their code sits in, and often explains which account reaches it. None of that should be published, so it never enters this repo at all.
 
-The `includeIf` line that points at such a file names the client's folder, so that line stays out of git too. What can be committed is the pattern itself, and `git-hub.config` is the example to copy.
+Instead, `gitconfig.local` carries one committed pointer:
+
+```
+[include]
+	path = ~/.gitconfig.client
+```
+
+Everything about clients lives behind that pointer, outside the repo and outside rcm's reach:
+
+- `~/.gitconfig.client` lists one `includeIf` per client, matching on the folder their work sits in.
+- `~/.gitconfig.<client>` holds that client's actual settings, such as the email to commit under or the SSH host alias that reaches their code.
+
+Git ignores an include whose file is missing, so a machine with no client work needs no change and nothing has to be commented out.
+
+Neither file is created by `rcup`, and neither will come back on its own. **Keep copies in 1Password.** `git-hub.config` shows the shape to copy, and stays committed because Hub is a thoughtbot product rather than a client.
 
 ## The thoughtbot checkouts are read-only
 

--- a/gitconfig.local
+++ b/gitconfig.local
@@ -41,3 +41,18 @@
 
 [includeIf "gitdir:~/Developer/thoughtbot/hub/"]
 	path = ~/dotfiles-local/git-hub.config
+
+# Client work is set up in ~/.gitconfig.client, which is kept outside this
+# repo on purpose. This repo is public, and naming a client, saying which
+# folder their code sits in, or explaining which account reaches it are all
+# things that should not be published. Only this pointer is shared.
+#
+# Nothing breaks when that file is absent. Git ignores an include whose file
+# is not there, so a fresh machine, or one with no client work on it, carries
+# on as normal. There is nothing to comment out.
+#
+# The file is not created by rcup and lives outside the repo, so it will not
+# come back on its own. Keep a copy in 1Password. See CLAUDE.md for what goes
+# in it, and git-hub.config for the shape to copy.
+[include]
+	path = ~/.gitconfig.client


### PR DESCRIPTION
Settings for a client name that client, say which folder their code
sits in, and explain which account reaches it. This repo is public, so
none of that belongs here.

Until now those lines were simply never committed. That kept them off
the internet, but it left the repo permanently showing an uncommitted
change, so real work in progress and a deliberate gap looked the same.
It also meant the arrangement was carried in somebody's head rather
than written down.

One pointer is committed instead, and everything about clients sits
behind it, outside this repo. ~/.gitconfig.client holds one rule per
client, matching the folder their work sits in, and each rule names a
file with that client's settings in it.

Nothing breaks when those files are absent. Git ignores an include when
the file is not there, so a fresh machine, or one doing no client work,
carries on under the personal name and address with no error. That was
checked by moving the file aside and watching git carry on.

The cost is that these files sit outside rcup's reach and will not come
back on their own, so they need a copy in 1Password. CLAUDE.md says so,
and so does a comment in each file.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>